### PR TITLE
Update minimum macOS version to `10_15`.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,9 @@ let buildTests = false
 let package = Package(
         name: "SwiftUIFormValidator",
         platforms: [
-            .macOS(.v10_14), .iOS(.v13), .tvOS(.v13)
+            .macOS(.v10_15),
+            .iOS(.v13),
+            .tvOS(.v13),
         ],
         products: [
             .library(name: "FormValidator", targets: ["FormValidator"])


### PR DESCRIPTION
Attempting to build this package for macOS throws a number of compiler errors due to `Published` only being available on `10.15` and up.

Bumping the version in `Package.swift` appears to resolve this.



<img width="1034" alt="published-error" src="https://user-images.githubusercontent.com/46851636/150676873-2d3c9e10-17c8-486d-ad97-eda84a866a64.png">
 